### PR TITLE
Change note on when Revise.jl doesn't work

### DIFF
--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -62,8 +62,8 @@ using MyModule # if you are in the folder where "MyModule.jl" is*
 You will be able to modify the functions inside those files and they
 will be always be automatically updated at every new call in the REPL. 
 
-These options do not work if you redefine a data structure. Then you
-have to restart over. I usually keep also a script which just runs the
+These options do not work if you redefine a constant, such as a struct or try to redefine a function as a variable. 
+Then you have to restart over. I usually keep also a script which just runs the
 above commands to restart the developing section when that is needed,
 starting julia with `julia -i devel.jl`.
 


### PR DESCRIPTION
Although the redefinition of a data structure indeed doesn't work with Revise, I do find that constants in general can be a bit problematic. For example:
```
julia> f(x) = x
f (generic function with 1 method)

julia> f = 3
ERROR: invalid redefinition of constant f
Stacktrace:
 [1] top-level scope
   @ REPL[2]:1
```
Also I'm not sure how you wanted to format the text, because it isn't clear what line length you try to stick to.
In general, I would advise to use a newline for any text formatting which ignores newlines, such as LaTeX, Markdown and HTML. The reason is that it works much better with Git diff and more advanced text editors like Vim or Emacs. For example, in the latter, you can easily cut and paste complete lines.