### PR TITLE
Add Julia compat to prevent CI failures on 1.0

### DIFF
--- a/docs/src/new_package.md
+++ b/docs/src/new_package.md
@@ -12,7 +12,7 @@ https://github.com/lmiq/MyPackage.jl
 
 ```julia
 using PkgTemplates
-tpl = Template(user="lmiq")
+tpl = Template(user="lmiq", julia=v"1.9", plugins=[Git(ssh=true)])
 tpl("MyPackage")
 ```
 

--- a/docs/src/new_package.md
+++ b/docs/src/new_package.md
@@ -12,7 +12,7 @@ https://github.com/lmiq/MyPackage.jl
 
 ```julia
 using PkgTemplates
-tpl = Template(user="lmiq", julia=v"1.9", plugins=[Git(ssh=true)])
+tpl = Template(user="lmiq", julia=v"1.9")
 tpl("MyPackage")
 ```
 


### PR DESCRIPTION
I am teaching students how to create a package and I drew inspiration from your notes, but the workflow you proposed fails in 2023. I identified two reasons:

- By default, PkgTemplates.jl uses HTTPS for the remote repo, which was deprecated by GitHub in 2021. The new right way is to use SSH
- By default, PkgTemplates.jl proposes compatibility with Julia v1.0, but when I pushed this the CI failed (unsurprisingly)

This PR fixes both